### PR TITLE
为避免循环callback降低了timeCache的性能，使用Keys方法替代Loop方法，来应对需要遍历的场景

### DIFF
--- a/timer_cache.go
+++ b/timer_cache.go
@@ -145,13 +145,12 @@ func (p *TimerCache) tryPop(tick int64, expireCb func(key, value interface{})) {
 	}
 }
 
-func (p *TimerCache) Loop(cb func(key, value interface{})) {
-	if cb == nil {
-		return
-	}
+func (p *TimerCache) Keys() []interface{} {
 	p.RLock()
 	defer p.RUnlock()
+	keys := []interface{}{}
 	for _, item := range p.m {
-		cb(item.key, item.value)
+		keys = append(keys, item.key)
 	}
+	return keys
 }

--- a/timer_cache.go
+++ b/timer_cache.go
@@ -149,8 +149,8 @@ func (p *TimerCache) Keys() []interface{} {
 	p.RLock()
 	defer p.RUnlock()
 	keys := []interface{}{}
-	for _, item := range p.m {
-		keys = append(keys, item.key)
+	for k, _ := range p.m {
+		keys = append(keys, k)
 	}
 	return keys
 }

--- a/timer_cache_test.go
+++ b/timer_cache_test.go
@@ -26,11 +26,9 @@ func TestTimeCache(t *testing.T) {
 		t.Error("1=> should be 3", val)
 	}
 
-	cb := func(k, v interface{}) {
-		fmt.Println("@k:", k, "@v:", v)
+	for k := range tc.Keys() {
+		fmt.Println("@k:", k)
 	}
-
-	tc.Loop(cb)
 
 	time.Sleep(4 * time.Second)
 


### PR DESCRIPTION
为避免循环callback降低了timeCache的性能，使用Keys方法替代Loop方法，来应对需要遍历的场景
